### PR TITLE
Allow `startingDateValue` and `endingDateValue` as string

### DIFF
--- a/src/components/DatePicker.vue
+++ b/src/components/DatePicker.vue
@@ -166,11 +166,11 @@
       },
       startingDateValue: {
         default: null,
-        type: Date
+        type: [Date, String]
       },
       endingDateValue: {
         default: null,
-        type: Date
+        type: [Date, String]
       },
       format: {
         default: 'YYYY-MM-DD',
@@ -253,8 +253,8 @@
     data() {
       return {
         hoveringDate: null,
-        checkIn: this.startingDateValue,
-        checkOut: this.endingDateValue,
+        checkIn: new Date(this.startingDateValue),
+        checkOut: new Date(this.endingDateValue),
         months: [],
         activeMonthIndex: 0,
         nextDisabledDate: null,


### PR DESCRIPTION
This commit simply creates a new `Date` from the value passed as `startingDateValue` or `endingDateValue` (and accepts the props as strings too, of course).